### PR TITLE
Add missing releases to downloads.html

### DIFF
--- a/download.html
+++ b/download.html
@@ -24,6 +24,123 @@ listed in the <a href="//llvm.org/docs/ReleaseNotes.html">Release Notes</a> for 
 next release.</p>
 </div>
 
+<table class="rel_section"><tr><td><a name="18.1.5">Download LLVM 18.1.5</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-18.1.5'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="18.1.4">Download LLVM 18.1.4</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-18.1.4'>page</a>.
+<p><b>Documentation:</b></p>
+<ul>
+  <li><a href="18.1.4/docs/index.html">LLVM</a> (<a href="18.1.4/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.4/tools/clang/docs/index.html">Clang</a> (<a href="18.1.4/tools/clang/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.4/tools/clang/tools/extra/docs/index.html">clang-tools-extra</a> (<a href="18.1.4/tools/clang/tools/extra/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.4/tools/lld/docs/index.html">LLD</a> (<a href="18.1.4/tools/lld/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.4/projects/libcxx/docs/index.html">libc++</a> (<a href="18.1.4/projects/libcxx/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.4/tools/polly/docs/index.html">Polly</a> (<a href="18.1.4/tools/polly/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.4/tools/flang/docs/index.html">Flang</a> (<a href="18.1.4/tools/flang/docs/ReleaseNotes.html">release notes</a>)</li>
+</ul>
+</div>
+
+<table class="rel_section"><tr><td><a name="18.1.3">Download LLVM 18.1.3</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-18.1.3'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="18.1.2">Download LLVM 18.1.2</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-18.1.2'>page</a>.
+<p><b>Documentation:</b></p>
+<ul>
+  <li><a href="18.1.2/docs/index.html">LLVM</a> (<a href="18.1.2/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.2/tools/clang/docs/index.html">Clang</a> (<a href="18.1.2/tools/clang/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.2/tools/clang/tools/extra/docs/index.html">clang-tools-extra</a> (<a href="18.1.2/tools/clang/tools/extra/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.2/tools/lld/docs/index.html">LLD</a> (<a href="18.1.2/tools/lld/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.2/projects/libcxx/docs/index.html">libc++</a> (<a href="18.1.2/projects/libcxx/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.2/tools/polly/docs/index.html">Polly</a> (<a href="18.1.2/tools/polly/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.2/tools/flang/docs/index.html">Flang</a> (<a href="18.1.2/tools/flang/docs/ReleaseNotes.html">release notes</a>)</li>
+</ul>
+</div>
+
+<table class="rel_section"><tr><td><a name="18.1.1">Download LLVM 18.1.1</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-18.1.1'>page</a>.
+<p><b>Documentation:</b></p>
+<ul>
+  <li><a href="18.1.1/docs/index.html">LLVM</a> (<a href="18.1.1/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.1/tools/clang/docs/index.html">Clang</a> (<a href="18.1.1/tools/clang/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.1/tools/clang/tools/extra/docs/index.html">clang-tools-extra</a> (<a href="18.1.1/tools/clang/tools/extra/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.1/tools/lld/docs/index.html">LLD</a> (<a href="18.1.1/tools/lld/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.1/projects/libcxx/docs/index.html">libc++</a> (<a href="18.1.1/projects/libcxx/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.1/tools/polly/docs/index.html">Polly</a> (<a href="18.1.1/tools/polly/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.1/tools/flang/docs/index.html">Flang</a> (<a href="18.1.1/tools/flang/docs/ReleaseNotes.html">release notes</a>)</li>
+</ul>
+</div>
+
+<table class="rel_section"><tr><td><a name="18.1.0">Download LLVM 18.1.0</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-18.1.0'>page</a>.
+<p><b>Documentation:</b></p>
+<ul>
+  <li><a href="18.1.0/docs/index.html">LLVM</a> (<a href="18.1.0/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.0/tools/clang/docs/index.html">Clang</a> (<a href="18.1.0/tools/clang/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.0/tools/clang/tools/extra/docs/index.html">clang-tools-extra</a> (<a href="18.1.0/tools/clang/tools/extra/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.0/tools/lld/docs/index.html">LLD</a> (<a href="18.1.0/tools/lld/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.0/projects/libcxx/docs/index.html">libc++</a> (<a href="18.1.0/projects/libcxx/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.0/tools/polly/docs/index.html">Polly</a> (<a href="18.1.0/tools/polly/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="18.1.0/tools/flang/docs/index.html">Flang</a> (<a href="18.1.0/tools/flang/docs/ReleaseNotes.html">release notes</a>)</li>
+</ul>
+</div>
+
+<table class="rel_section"><tr><td><a name="17.0.6">Download LLVM 17.0.6</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-17.0.6'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="17.0.5">Download LLVM 17.0.5</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-17.0.5'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="17.0.4">Download LLVM 17.0.4</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-17.0.4'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="17.0.3">Download LLVM 17.0.3</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-17.0.3'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="17.0.2">Download LLVM 17.0.2</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-17.0.2'>page</a>.<p>
+</div>
+
 <table class="rel_section"><tr><td><a name="17.0.1">Download LLVM 17.0.1</a></td></tr></table>
 <div class="rel_boxtext">
 <p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
@@ -41,6 +158,19 @@ These are available on the GitHub release <a href='https://github.com/llvm/llvm-
 </ul>
 </div>
 
+<table class="rel_section"><tr><td><a name="16.0.6">Download LLVM 16.0.4</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-16.0.6'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="16.0.5">Download LLVM 16.0.4</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-16.0.5'>page</a>.<p>
+</div>
 
 <table class="rel_section"><tr><td><a name="16.0.4">Download LLVM 16.0.4</a></td></tr></table>
 <div class="rel_boxtext">


### PR DESCRIPTION
Clang Info -> Download at https://clang.llvm.org/ links to the download.html contained in this repository. This list lacks a lot of minor releases, but also llvm/clang 18. This patch adds the missing releases

* 16.0.5
* 16.0.6
* 17.0.2
* 17.0.3
* 17.0.4
* 17.0.5
* 17.0.6
* 18.1.0
* 18.1.1
* 18.1.2
* 18.1.3
* 18.1.4
* 18.1.5