### PR TITLE
Fix duplicate '18.1.4' entries in release list

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@ function addReleases() {
     ['18 May 2024', '18.1.6', ['https://discourse.llvm.org/t/18-1-6-released/79068'],[]],
     ['2 May 2024', '18.1.5', ['https://discourse.llvm.org/t/18-1-5-released/78740'],[]],
     ['17 Apr 2024', '18.1.4', ['https://discourse.llvm.org/t/18-1-4-released/78430'],[]],
-    ['17 Apr 2024', '18.1.4', ['https://discourse.llvm.org/t/18-1-4-released/78430'],[]], 
+    ['4 Apr 2024', '18.1.3', ['https://discourse.llvm.org/t/18-1-3-released/78136'],[]],
     ['19  Mar 2024', '18.1.2', ['https://discourse.llvm.org/t/18-1-2-released/77821'],[]], 
     ['8  Mar 2024', '18.1.1', ['https://discourse.llvm.org/t/llvm-18-1-1-released/77540'],[]], 
     ['5  Mar 2024', '18.1.0',  ['llvm', 'clang', 'lld', 'clang-extra', 'libc++', 'polly', 'flang'], ['llvm', 'clang', 'lld', 'clang-extra', 'libc++', 'polly', 'flang']],


### PR DESCRIPTION
Closes llvm/llvm-project#99635