### PR TITLE
Use better wording

### DIFF
--- a/19.1.0/docs/_sources/tutorial/MyFirstLanguageFrontend/LangImpl03.rst.txt
+++ b/19.1.0/docs/_sources/tutorial/MyFirstLanguageFrontend/LangImpl03.rst.txt
@@ -182,7 +182,7 @@ Binary operators start to get more interesting. The basic idea here is
 that we recursively emit code for the left-hand side of the expression,
 then the right-hand side, then we compute the result of the binary
 expression. In this code, we do a simple switch on the opcode to create
-the right LLVM instruction.
+the correct LLVM instruction.
 
 In the example above, the LLVM builder class is starting to show its
 value. IRBuilder knows where to insert the newly created instruction,


### PR DESCRIPTION
The phrase "create the *right* LLVM instruction" when talking about left-hand side and *right*-hand-side of binary operators can be confusing. Instead "create the correct LLVM instruction" does not cause a re-read for understanding.