### PR TITLE
Fix incorrect version number displayed for 16.0.5 and 16.0.6 releases

### DIFF
--- a/download.html
+++ b/download.html
@@ -209,14 +209,14 @@ These are available on the GitHub release <a href='https://github.com/llvm/llvm-
 </ul>
 </div>
 
-<table class="rel_section"><tr><td><a name="16.0.6">Download LLVM 16.0.4</a></td></tr></table>
+<table class="rel_section"><tr><td><a name="16.0.6">Download LLVM 16.0.6</a></td></tr></table>
 <div class="rel_boxtext">
 <p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
 
 These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-16.0.6'>page</a>.<p>
 </div>
 
-<table class="rel_section"><tr><td><a name="16.0.5">Download LLVM 16.0.4</a></td></tr></table>
+<table class="rel_section"><tr><td><a name="16.0.5">Download LLVM 16.0.5</a></td></tr></table>
 <div class="rel_boxtext">
 <p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
 


### PR DESCRIPTION
There were 3 headings that said 16.0.4, two of which are for 16.0.5 and 16.06. The links and names were otherwise correct for those two releases.