### PR TITLE
Update index and download pages with 21.1.6 release

### DIFF
--- a/download.html
+++ b/download.html
@@ -24,6 +24,23 @@ listed in the <a href="//llvm.org/docs/ReleaseNotes.html">Release Notes</a> for 
 next release.</p>
 </div>
 
+<table class="rel_section"><tr><td><a name="21.1.6">Download LLVM 21.1.6</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.6'>page</a>.
+<p><b>Documentation:</b></p>
+<ul>
+  <li><a href="21.1.6/docs/index.html">LLVM</a> (<a href="21.1.6/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="21.1.6/tools/clang/docs/index.html">Clang</a> (<a href="21.1.6/tools/clang/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="21.1.6/tools/clang/tools/extra/docs/index.html">clang-tools-extra</a> (<a href="21.1.6/tools/clang/tools/extra/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="21.1.6/tools/lld/docs/index.html">LLD</a> (<a href="21.1.6/tools/lld/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="21.1.6/projects/libcxx/docs/index.html">libc++</a> (<a href="21.1.6/projects/libcxx/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="21.1.6/tools/polly/docs/index.html">Polly</a> (<a href="21.1.6/tools/polly/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="21.1.6/tools/flang/docs/index.html">Flang</a> (<a href="21.1.6/tools/flang/docs/ReleaseNotes.html">release notes</a>)</li>
+</ul>
+</div>
+
 <table class="rel_section"><tr><td><a name="18.1.8">Download LLVM 18.1.8</a></td></tr></table>
 <div class="rel_boxtext">
 <p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>

--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@ function addReleases() {
 
   // date, version, [releasenotes, docs].
   var RELEASES = [
+    ['18 Nov 2025', '21.1.6', ['llvm', 'clang', 'lld', 'clang-extra', 'libc++', 'polly', 'flang'], ['llvm', 'clang', 'lld', 'clang-extra', 'libc++', 'polly', 'flang']],
     ['26 Aug 2025', '21.1.0',  ['llvm', 'clang', 'lld', 'clang-extra', 'libc++', 'polly', 'flang'], ['llvm', 'clang', 'lld', 'clang-extra', 'libc++', 'polly', 'flang']],
     ['04 Mar 2025', '20.1.0',  ['llvm', 'clang', 'lld', 'clang-extra', 'libc++', 'polly', 'flang'], ['llvm', 'clang', 'lld', 'clang-extra', 'libc++', 'polly', 'flang']],
     ['1 Oct 2024', '19.1.1',  ['https://discourse.llvm.org/t/llvm-19-1-1-released/82321'], []],


### PR DESCRIPTION
Adds entry for 21.1.6 release to the index.html and download.html pages. Depends on #23 to make the documentation pages linked to be valid.