### PR TITLE
Add entries on download page for 19.1.0 to 19.1.7, 20.1.0 to 20.1.8, and 21.1.0 to 21.1.5

### DIFF
--- a/download.html
+++ b/download.html
@@ -24,6 +24,207 @@ listed in the <a href="//llvm.org/docs/ReleaseNotes.html">Release Notes</a> for 
 next release.</p>
 </div>
 
+<table class="rel_section"><tr><td><a name="21.1.5">Download LLVM 21.1.5</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.5'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="21.1.4">Download LLVM 21.1.4</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.4'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="21.1.3">Download LLVM 21.1.3</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.3'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="21.1.2">Download LLVM 21.1.2</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.2'>page</a>.
+<p><b>Documentation:</b></p>
+<ul>
+  <li><a href="21.1.2/docs/index.html">LLVM</a> (<a href="21.1.2/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="21.1.2/tools/clang/docs/index.html">Clang</a> (<a href="21.1.2/tools/clang/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="21.1.2/tools/clang/tools/extra/docs/index.html">clang-tools-extra</a> (<a href="21.1.2/tools/clang/tools/extra/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="21.1.2/tools/lld/docs/index.html">LLD</a> (<a href="21.1.2/tools/lld/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="21.1.2/projects/libcxx/docs/index.html">libc++</a> (<a href="21.1.2/projects/libcxx/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="21.1.2/tools/polly/docs/index.html">Polly</a> (<a href="21.1.2/tools/polly/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="21.1.2/tools/flang/docs/index.html">Flang</a> (<a href="21.1.2/tools/flang/docs/ReleaseNotes.html">release notes</a>)</li>
+</ul>
+</div>
+
+<table class="rel_section"><tr><td><a name="21.1.1">Download LLVM 21.1.1</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.1'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="21.1.0">Download LLVM 21.1.0</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-21.1.0'>page</a>.
+<p><b>Documentation:</b></p>
+<ul>
+  <li><a href="21.1.0/docs/index.html">LLVM</a> (<a href="21.1.0/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="21.1.0/tools/clang/docs/index.html">Clang</a> (<a href="21.1.0/tools/clang/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="21.1.0/tools/clang/tools/extra/docs/index.html">clang-tools-extra</a> (<a href="21.1.0/tools/clang/tools/extra/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="21.1.0/tools/lld/docs/index.html">LLD</a> (<a href="21.1.0/tools/lld/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="21.1.0/projects/libcxx/docs/index.html">libc++</a> (<a href="21.1.0/projects/libcxx/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="21.1.0/tools/polly/docs/index.html">Polly</a> (<a href="21.1.0/tools/polly/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="21.1.0/tools/flang/docs/index.html">Flang</a> (<a href="21.1.0/tools/flang/docs/ReleaseNotes.html">release notes</a>)</li>
+</ul>
+</div>
+
+<table class="rel_section"><tr><td><a name="20.1.8">Download LLVM 20.1.8</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.8'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="20.1.7">Download LLVM 20.1.7</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.7'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="20.1.6">Download LLVM 20.1.6</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.6'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="20.1.5">Download LLVM 20.1.5</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.5'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="20.1.4">Download LLVM 20.1.4</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.4'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="20.1.3">Download LLVM 20.1.3</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.3'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="20.1.2">Download LLVM 20.1.2</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.2'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="20.1.1">Download LLVM 20.1.1</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.1'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="20.1.0">Download LLVM 20.1.0</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.0'>page</a>.
+<p><b>Documentation:</b></p>
+<ul>
+  <li><a href="20.1.0/docs/index.html">LLVM</a> (<a href="20.1.0/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="20.1.0/tools/clang/docs/index.html">Clang</a> (<a href="20.1.0/tools/clang/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="20.1.0/tools/clang/tools/extra/docs/index.html">clang-tools-extra</a> (<a href="20.1.0/tools/clang/tools/extra/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="20.1.0/tools/lld/docs/index.html">LLD</a> (<a href="20.1.0/tools/lld/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="20.1.0/projects/libcxx/docs/index.html">libc++</a> (<a href="20.1.0/projects/libcxx/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="20.1.0/tools/polly/docs/index.html">Polly</a> (<a href="20.1.0/tools/polly/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="20.1.0/tools/flang/docs/index.html">Flang</a> (<a href="20.1.0/tools/flang/docs/ReleaseNotes.html">release notes</a>)</li>
+</ul>
+</div>
+
+<table class="rel_section"><tr><td><a name="19.1.7">Download LLVM 19.1.7</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.7'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="19.1.6">Download LLVM 19.1.6</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.6'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="19.1.5">Download LLVM 19.1.5</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.5'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="19.1.4">Download LLVM 19.1.4</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.4'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="19.1.3">Download LLVM 19.1.3</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.3'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="19.1.2">Download LLVM 19.1.2</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.2'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="19.1.1">Download LLVM 19.1.1</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.1'>page</a>.<p>
+</div>
+
+<table class="rel_section"><tr><td><a name="19.1.0">Download LLVM 19.1.0</a></td></tr></table>
+<div class="rel_boxtext">
+<p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>
+
+These are available on the GitHub release <a href='https://github.com/llvm/llvm-project/releases/tag/llvmorg-19.1.0'>page</a>.
+<p><b>Documentation:</b></p>
+<ul>
+  <li><a href="19.1.0/docs/index.html">LLVM</a> (<a href="19.1.0/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="19.1.0/tools/clang/docs/index.html">Clang</a> (<a href="19.1.0/tools/clang/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="19.1.0/tools/clang/tools/extra/docs/index.html">clang-tools-extra</a> (<a href="19.1.0/tools/clang/tools/extra/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="19.1.0/tools/lld/docs/index.html">LLD</a> (<a href="19.1.0/tools/lld/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="19.1.0/projects/libcxx/docs/index.html">libc++</a> (<a href="19.1.0/projects/libcxx/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="19.1.0/tools/polly/docs/index.html">Polly</a> (<a href="19.1.0/tools/polly/docs/ReleaseNotes.html">release notes</a>)</li>
+  <li><a href="19.1.0/tools/flang/docs/index.html">Flang</a> (<a href="19.1.0/tools/flang/docs/ReleaseNotes.html">release notes</a>)</li>
+</ul>
+</div>
+
 <table class="rel_section"><tr><td><a name="18.1.8">Download LLVM 18.1.8</a></td></tr></table>
 <div class="rel_boxtext">
 <p><b>Sources / Pre-Built Binaries / Doxygen:</b></p>


### PR DESCRIPTION
Adds entries with links to release notes for recent releases that are missing from the index page.

Specifically: 19.1.0, 19.1.1, 19.1.2, 19.1.3, 19.1.4, 19.1.5, 19.1.6, 19.1.7, 20.1.0, 20.1.1, 20.1.2, 20.1.3, 20.1.4, 20.1.5, 20.1.6, 20.1.7, 20.1.8, 21.1.0, 21.1.1, 21.1.2, 21.1.3, 21.1.4, and 21.1.5